### PR TITLE
[`trac_ik_python`]: Add suport for ROS 2

### DIFF
--- a/trac_ik_python/package.xml
+++ b/trac_ik_python/package.xml
@@ -7,24 +7,23 @@
   <author>Sam Pfeiffer</author>
   <maintainer email="Sammy.Pfeiffer@student.uts.edu.au">Sam Pfeiffer</maintainer>
   <maintainer email="robotics@traclabs.com">TRACLabs Robotics</maintainer>
+  <maintainer email="abrar.rahman98@gmail.com">Abrar Rahman Protyasha</maintainer>
   <license>BSD</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
-  <build_depend>rospy</build_depend>
+  <build_depend>libnlopt-cxx-dev</build_depend>
+  <build_depend>rclpy</build_depend>
   <build_depend>swig</build_depend>
+  <build_depend>tf2_kdl</build_depend>
   <build_depend>trac_ik_lib</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>libnlopt-dev</build_depend>
-  <build_depend condition="$ROS_DISTRO == noetic">libnlopt-cxx-dev</build_depend>
 
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>swig</exec_depend>
-  <exec_depend>trac_ik_lib</exec_depend>
-  <exec_depend>tf_conversions</exec_depend>
-  <exec_depend>tf</exec_depend>
-  <exec_depend>libnlopt-dev</exec_depend>
   <exec_depend>libnlopt0</exec_depend>
-
+  <exec_depend>libnlopt-cxx-dev</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>swig</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_kdl</exec_depend>
+  <exec_depend>trac_ik_lib</exec_depend>
 </package>


### PR DESCRIPTION
[This PR will go out of draft once it's ready for review.]

This PR will target porting efforts for `trac_ik_python`,
please refer to #1 for more context/discourse.

Changes:
* `package.xml`:
  * Listed myself as a maintainer.
  * Introduced `buildtool_depend` tag on `ament_cmake_python`.
  * `rospy` -> `rclpy`.
  * `tf` -> `tf2`.

Signed-off-by: aprotyas <aprotyas@u.rochester.edu>
