### PR TITLE
[trac_ik_python]: Add suport for ROS 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ROS 2 port of `trac_ik`, an alternative Inverse Kinematics solver to the popular inverse Jacobian methods in KDL.
 
+dependencies:
+- sudo apt install libnlopt-cxx0 libnlopt-cxx-dev
+- sudo apt install swig
+
 Link to the original repository: https://bitbucket.org/traclabs/trac_ik/src/master/
 
 ---

--- a/trac_ik_lib/CMakeLists.txt
+++ b/trac_ik_lib/CMakeLists.txt
@@ -50,6 +50,8 @@ ament_target_dependencies(trac_ik
 
 ament_export_targets(export_trac_ik HAS_LIBRARY_TARGET)
 
+ament_export_libraries(trac_ik)
+ament_export_include_directories(include)
 ament_export_dependencies(
     ament_cmake
     Eigen3

--- a/trac_ik_python/CMakeLists.txt
+++ b/trac_ik_python/CMakeLists.txt
@@ -1,16 +1,53 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(trac_ik_python)
 
-add_compile_options(-std=c++11 -Wno-deprecated)
+# Add support for C++14
+#if(NOT CMAKE_CXX_STANDARD)
+#  set(CMAKE_CXX_STANDARD 14)
+#endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclpy REQUIRED)
+find_package(trac_ik_lib REQUIRED)
+find_package(PythonLibs REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(tf2_kdl REQUIRED)
+#find_package(tf_conversions REQUIRED)
+
+# set(INCLUDE_DIRS ${ament_cmake_INCLUDE_DIRS} ${rclpy_INCLUDE_DIRS}
+#   ${trac_ik_lib_INCLUDE_DIRS} ${tf_conversions_INCLUDE_DIRS})
+# include_directories(${INCLUDE_DIRS})
+
+# set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${rclpy_LIBRARY_DIRS}
+#   ${trac_ik_lib_LIBRARY_DIRS} ${tf_conversions_LIBRARY_DIRS})
+
+# link_directories(${LIBRARY_DIRS})
+
+# set(LIBS ${ament_cmake_LIBRARIES} ${rclpy_LIBRARIES} ${trac_ik_lib_LIBRARIES}
+#   ${tf_conversions_LIBRARIES})
+
+message(STATUS "TRACLIB includes: ${trac_ik_lib_INCLUDE_DIRS}")
+set(INCLUDE_DIRS ${ament_cmake_INCLUDE_DIRS} ${ament_cmake_python_INCLUDE_DIRS} ${rclpy_INCLUDE_DIRS}
+  ${trac_ik_lib_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
+include_directories(${INCLUDE_DIRS})
+#include_directories(${trac_ik_lib_INCLUDE_DIRS})
+message(STATUS "INCLUDES: ${INCLUDE_DIRS}")
+
+set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${rclpy_LIBRARY_DIRS}
+  ${trac_ik_lib_LIBRARY_DIRS})
+
+link_directories(${LIBRARY_DIRS})
+
+set(LIBS ${ament_cmake_LIBRARIES} ${rclpy_LIBRARIES} ${trac_ik_lib_LIBRARIES})
+
+
+#add_compile_options(-std=c++11 -Wno-deprecated)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  rospy
-  trac_ik_lib
-  tf_conversions
-)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(pkg_nlopt REQUIRED nlopt)
@@ -25,12 +62,9 @@ else()
   find_package(PythonLibs REQUIRED)
 endif()
 
-catkin_python_setup()
-
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package()
 
 ###########
 ## Build ##
@@ -42,30 +76,16 @@ catkin_package()
 include(${SWIG_USE_FILE})
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swig)
 
-# To add trac_ik_lib headers (from this ros answers: http://answers.ros.org/question/201977/include-header-file-from-another-package-indigo/)
-include_directories(${catkin_INCLUDE_DIRS} ${pkg_nlopt_INCLUDE_DIRS})
 
+# To add trac_ik_lib headers (from this ros answers: http://answers.ros.org/question/201977/include-header-file-from-another-package-indigo/)
 
 # Python trac_ik wrapper using SWIG
 # Based on: https://github.com/kdhansen/Aseta/blob/36a7a104f3430ff8b54416a07062234673a73762/src/gatsp/CMakeLists.txt
-SET_SOURCE_FILES_PROPERTIES(
-  swig/trak_ik_wrap.i PROPERTIES CPLUSPLUS ON 
-)
+set_source_files_properties(swig/trak_ik_wrap.i PROPERTIES CPLUSPLUS ON)
 
 if(DEFINED ENV{ROS_PYTHON_VERSION} AND ENV{ROS_PYTHON_VERSION} EQUAL 3)
-  include_directories(
-    ${Python3_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
-    ${pkg_nlopt_INCLUDE_DIRS}
-  )
 else()
-  include_directories(
-    ${PYTHON_INCLUDE_DIRS} # This solved Python.h: No such file or directory
-    ${Boost_INCLUDE_DIRS}
-  )
 endif()
-
-
 
 # To overcome (took me hours to notice):
 # /opt/ros/indigo/include/kdl/utilities/utility.h:27:19: fatal error: cstdlib: No such file or directory
@@ -80,55 +100,64 @@ set(CMAKE_SWIG_FLAGS "-c++")
 # This actually makes the compilation of the generated trac_ik_wrapPYTHON_wrap.c happen
 if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
   # SWIG_ADD_MODULE is deprecated from 3.8.0
-  SWIG_ADD_MODULE(trac_ik_wrap python
-  swig/trac_ik_wrap.i
-  )
+  swig_add_module(trac_ik_wrap python swig/trac_ik_wrap.i)
 else()
-  SWIG_ADD_LIBRARY(trac_ik_wrap
-    LANGUAGE python
-    SOURCES swig/trac_ik_wrap.i
-  )
+  swig_add_library(trac_ik_wrap LANGUAGE python SOURCES swig/trac_ik_wrap.i)
 endif()
 
 # Link the wrapper with the actual library
 
 if(DEFINED ENV{ROS_PYTHON_VERSION} AND ENV{ROS_PYTHON_VERSION} EQUAL 3)
-  SWIG_LINK_LIBRARIES(trac_ik_wrap ${Python3_LIBRARIES} ${catkin_LIBRARIES})
+  swig_link_libraries(trac_ik_wrap ${Python3_LIBRARIES} ${catkin_LIBRARIES})
 else()
-  SWIG_LINK_LIBRARIES(trac_ik_wrap ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
+  swig_link_libraries(trac_ik_wrap ${PYTHON_LIBRARIES} ${catkin_LIBRARIES})
 endif()
 
 # The name '_trac_ik_wrap' is given by SWIG, haven't found how to change it
-set_target_properties(_trac_ik_wrap
-  PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
+# set_target_properties(_trac_ik_wrap
+#   PROPERTIES
+#   LIBRARY_OUTPUT_DIRECTORY
+#   ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+
+# set_source_files_properties(swig/trac_ik_wrap.i PROPERTIES 
+#         CPLUSPLUS ON
+#         INCLUDE_DIRECTORIES ${trac_ik_lib_INCLUDE_DIRS}
+# 		)
 
 
-#############
-## Install ##
-#############
+# #############
+# ## Install ##
+# #############
 
-add_custom_command(TARGET _trac_ik_wrap POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/trac_ik_wrap.py ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
+# add_custom_command(TARGET _trac_ik_wrap
+#   POST_BUILD
+#   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/trac_ik_wrap.py
+#   ${CATKIN_PACKAGE_PYTHON_DESTINATION})
 
-add_custom_command(TARGET _trac_ik_wrap POST_BUILD
-                   COMMAND touch ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/__init__.py
-)
+# add_custom_command(TARGET _trac_ik_wrap
+#   POST_BUILD
+#   COMMAND touch
+#   ${CATKIN_PACKAGE_PYTHON_DESTINATION}/__init__.py)
 
-# Install the trac_ik_wrap.py generated file
-# Needs to be done after creating the python wrapper (usually this is done at the top)
+# # Install the trac_ik_wrap.py generated file
+# # Needs to be done after creating the python wrapper (usually this is done at the top)
+
+# install(FILES
+#   ${CATKIN_PACKAGE_PYTHON_DESTINATION}/trac_ik_wrap.py
+#   ${CATKIN_PACKAGE_PYTHON_DESTINATION}/_trac_ik_wrap.so
+#   src/trac_ik_python/trac_ik.py src/trac_ik_python/__init__.py
+#   DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+
+# catkin_install_python(PROGRAMS scripts/test_pkg.py scripts/test_wrapper.py
+#   DESTINATION lib/${PROJECT_NAME})
 
 
-install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/trac_ik_wrap.py ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_trac_ik_wrap.so
-src/trac_ik_python/trac_ik.py
-src/trac_ik_python/__init__.py
-  DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
+# install(TARGETS swig/trac_ik_wrap.py LIBRARY DESTINATION lib)
+# install(TARGETS swig/_trac_ik_wrap.so LIBRARY DESTINATION lib)
 
-catkin_install_python(PROGRAMS scripts/test_pkg.py scripts/test_wrapper.py
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+#ament_target_dependencies(_trac_ik_wrap.so trac_ik_lib)
 
+ament_python_install_package(src/${PROJECT_NAME})
 
 #############
 ## Testing ##
@@ -144,3 +173,12 @@ catkin_install_python(PROGRAMS scripts/test_pkg.py scripts/test_wrapper.py
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
+
+ament_export_dependencies(ament_cmake)
+ament_export_dependencies(ament_cmake_python)
+ament_export_dependencies(rclpy)
+ament_export_dependencies(trac_ik_lib)
+#ament_export_dependencies(tf_conversions)
+ament_export_include_directories(${INCLUDE_DIRS})
+
+ament_package()

--- a/trac_ik_python/package.xml
+++ b/trac_ik_python/package.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<package format="3">
+<?xml version='1.0' encoding='utf-8'?>
+<package format="2">
   <name>trac_ik_python</name>
   <version>1.6.6</version>
   <description>The trac_ik_python package contains a python wrapper using SWIG
@@ -10,21 +10,21 @@
   <license>BSD</license>
 
 
-  <buildtool_depend>catkin</buildtool_depend>
-
-  <build_depend>rospy</build_depend>
   <build_depend>swig</build_depend>
   <build_depend>trac_ik_lib</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>libnlopt-dev</build_depend>
-  <build_depend condition="$ROS_DISTRO == noetic">libnlopt-cxx-dev</build_depend>
 
-  <exec_depend>rospy</exec_depend>
+  <build_depend>libnlopt-dev</build_depend>
+  <build_depend>libnlopt-cxx-dev</build_depend>
+
   <exec_depend>swig</exec_depend>
   <exec_depend>trac_ik_lib</exec_depend>
-  <exec_depend>tf_conversions</exec_depend>
-  <exec_depend>tf</exec_depend>
+
   <exec_depend>libnlopt-dev</exec_depend>
   <exec_depend>libnlopt0</exec_depend>
 
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
 </package>

--- a/trac_ik_python/src/trac_ik_python/trac_ik.py
+++ b/trac_ik_python/src/trac_ik_python/trac_ik.py
@@ -4,13 +4,13 @@
 # Convenience code to wrap TRAC IK
 
 from trac_ik_python.trac_ik_wrap import TRAC_IK
-import rospy
+
 
 
 class IK(object):
     def __init__(self, base_link, tip_link,
                  timeout=0.005, epsilon=1e-5, solve_type="Speed",
-                 urdf_string=None):
+                 urdf_string):
         """
         Create a TRAC_IK instance and keep track of it.
 
@@ -20,11 +20,9 @@ class IK(object):
         :param float epsilon: Error epsilon.
         :param solve_type str: Type of solver, can be:
             Speed (default), Distance, Manipulation1, Manipulation2
-        :param urdf_string str: Optional arg, if not given URDF is taken from
-            the param server at /robot_description.
+        :param urdf_string str: robot urdf
         """
-        if urdf_string is None:
-            urdf_string = rospy.get_param('/robot_description')
+
         self._urdf_string = urdf_string
         self._timeout = timeout
         self._epsilon = epsilon


### PR DESCRIPTION
trac_ik_python bindings:
- used the catkin-to-ament script to convert the CMakeLists, plus some tinkering
- changed from rospy to rclpy
- removed the reading of robot_description from parameters

I now stumble upon a SWIG error:
This warning: "trac_ik/trac_ik_python/swig/trac_ik_wrap.i:298: Warning 303: %extend defined for an undeclared class TRAC_IK::TRAC_IK." 
probably leads to the cascade of errors I got:
"build/trac_ik_python/CMakeFiles/_trac_ik_wrap.dir/trac_ik_wrapPYTHON_wrap.c:13463:24: error: ‘temp’ was not declared in this scope
13463 |       TRAC_IK_PUBLIC * temp;" ...
My understanding is that SWIG does not find the TRAC_IK class, maybe due to a namespace problem?

I tried with a very basic trac_ik_wrap.i with just the include to expose the class and got the same error.

 