### PR TITLE
[CI] Specify packages to action-ros-ci directly

### DIFF
--- a/.github/workflows/trac_ik_ci.yml
+++ b/.github/workflows/trac_ik_ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        package: [trac_ik_lib, trac_ik_examples]
         ros_distribution: [foxy, galactic, rolling]
     steps:
       - uses: actions/checkout@v2.3.4
@@ -31,7 +30,10 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.2
         id: action_ros_ci
         with:
-          package-name: ${{ matrix.package }}
+          package-name: |
+            trac_ik
+            trac_ik_examples
+            trac_ik_lib
           target-ros2-distro: ${{ matrix.ros_distribution }}
 
       - name: Upload Logs


### PR DESCRIPTION
This reduces the number of workers spawned for CI, since the packages are all built/tested together rather than as separate jobs in a matrix.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>