### PR TITLE
[trac_ik_lib] Add getter for SolveType

### DIFF
--- a/trac_ik_lib/include/trac_ik/trac_ik.hpp
+++ b/trac_ik_lib/include/trac_ik/trac_ik.hpp
@@ -127,6 +127,11 @@ public:
     solvetype = _type;
   }
 
+  inline SolveType GetSolveType() const
+  {
+    return solvetype;
+  }
+
 private:
   bool initialized;
   KDL::Chain chain;


### PR DESCRIPTION
Allows simpler Python bindings for the private `solvetype` attribute of
the `TRAC_IK` class.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>